### PR TITLE
通知から開くとヘッダーがなくなって身動きが取れなくなる問題対応 #29

### DIFF
--- a/MapTodo/AppDelegate.swift
+++ b/MapTodo/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     let placeViewController = R.storyboard.main.placeView()!
                     placeViewController.place = place
                     let navController = window?.rootViewController as! UINavigationController
-                    (navController).setViewControllers([navController.viewControllers.first!, placeViewController], animated: false)
+                    navController.setViewControllers([navController.viewControllers.first!, placeViewController], animated: false)
                 }
             }
         }

--- a/MapTodo/AppDelegate.swift
+++ b/MapTodo/AppDelegate.swift
@@ -36,8 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 if let place = Place.get(uiid: region) {
                     let placeViewController = R.storyboard.main.placeView()!
                     placeViewController.place = place
-                    (window?.rootViewController as! UINavigationController).popToRootViewController(animated: false)
-                    (window?.rootViewController as! UINavigationController).pushViewController(placeViewController, animated: false)
+                    let navController = window?.rootViewController as! UINavigationController
+                    (navController).setViewControllers([navController.viewControllers.first!, placeViewController], animated: false)
                 }
             }
         }

--- a/MapTodo/AppDelegate.swift
+++ b/MapTodo/AppDelegate.swift
@@ -36,7 +36,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 if let place = Place.get(uiid: region) {
                     let placeViewController = R.storyboard.main.placeView()!
                     placeViewController.place = place
-                    window!.rootViewController?.present(placeViewController, animated: false, completion: nil)
+                    (window?.rootViewController as! UINavigationController).popToRootViewController(animated: false)
+                    (window?.rootViewController as! UINavigationController).pushViewController(placeViewController, animated: false)
                 }
             }
         }


### PR DESCRIPTION
1行目の変更は、もともとplaceViewにいた状態でpushから開いたときに戻るボタンを押してもまだplaceViewになることを防ぐためにいれました